### PR TITLE
Resolutionbarre

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -56,23 +56,24 @@ function load_quagga(){
       Quagga.onDetected(function(result) {
         var last_code = result.codeResult.code;
         last_result.push(last_code);
+
         if (last_result.length > 20) {
           const code = order_by_occurrence(last_result)[0];
           last_result = [];
           Quagga.stop();
 
 
+
+
+
+
+
     var xmlHttp = new XMLHttpRequest();
-    xmlHttp.open( "GET", `/product/${code}`, false ); // false for synchronous request
+    xmlHttp.open( "GET", `/product/${code}`, true ); // false for synchronous request
     xmlHttp.send( null );
-    return xmlHttp.responseText;
+    console.log(code)
+    window.location.href = `/product/${code}`;
 
-
-
-          // $.ajax({
-          //   type: "GET",
-          //   url: `/product/${code}`,
-          // });
         }
       });
     }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -49,7 +49,6 @@ function order_by_occurrence(arr) {
 }
 
 function load_quagga(){
-  console.log("load quagga");
   if ($('#barcode-scanner').length > 0 && navigator.mediaDevices && typeof navigator.mediaDevices.getUserMedia === 'function') {
 
     var last_result = [];
@@ -57,10 +56,8 @@ function load_quagga(){
       Quagga.onDetected(function(result) {
         var last_code = result.codeResult.code;
         last_result.push(last_code);
-        console.log(last_code);
         if (last_result.length > 20) {
           const code = order_by_occurrence(last_result)[0];
-          console.log(code);
           last_result = [];
           Quagga.stop();
 


### PR DESCRIPTION
ca y est ca marche ! Par contre attention il faut que le code barre soit nickel, fond blanc de preference et support rigide et plat ! le scanner n’aime pas trop les formes arrondies